### PR TITLE
update SDKs and chain version

### DIFF
--- a/docs/sdks/languages.md
+++ b/docs/sdks/languages.md
@@ -8,13 +8,15 @@ title: Languages
 
 **Language** | **Version**	| **Repository** |	**Reference** |	**Active Developers**
 -------------|--------------|----------------|----------------|----------------------
-TypeScript & JS SDK | 0.6.3	| [Repository](https://github.com/proximax-storage/tsjs-xpx-chain-sdk) |	[Documentation](https://github.com/proximax-storage/tsjs-xpx-chain-sdk/wiki) |	[@proximax-storage](https://github.com/proximax-storage)
-Java SDK | 0.6.1 | [Repository](https://github.com/proximax-storage/java-xpx-chain-sdk) |	[Documentation](https://github.com/proximax-storage/java-xpx-chain-sdk/wiki) |	[@proximax-storage](https://github.com/proximax-storage)
-C# SDK 	| 0.6.1 | [Repository](https://github.com/proximax-storage/csharp-xpx-chain-sdk/ ) 	| [Documentation](https://github.com/proximax-storage/csharp-xpx-chain-sdk/wiki) | 	[@proximax-storage](https://github.com/proximax-storage)
-Go SDK | 0.6.0 |	[Repository](https://github.com/proximax-storage/go-xpx-chain-sdk/) 	| [Documentation](https://github.com/proximax-storage/go-xpx-chain-sdk/wiki) | 	[@proximax-storage](https://github.com/proximax-storage)
-Dart SDK | 0.0.5+1 | [Repository](https://github.com/proximax-storage/dart-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/dart-xpx-chain-sdk/wiki) | [@proximax-storage](https://github.com/proximax-storage)
-Python SDK | 0.6.0 | [Repository](https://github.com/proximax-storage/python-xpx-chain-sdk) | [Documentation](https://github.com/proximax-storage/python-xpx-chain-sdk/wiki) | [@proximax-storage](https://github.com/proximax-storage)
-PHP SDK | 0.1.0	| [Repository](https://github.com/proximax-storage/php-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/php-xpx-chain-sdk/wiki)  | [@proximax-storage](https://github.com/proximax-storage)
+Go SDK       | 0.7.0        | [Repository](https://github.com/proximax-storage/go-xpx-chain-sdk/) 	| [Documentation](https://github.com/proximax-storage/go-xpx-chain-sdk/wiki) | 	[@proximax-storage](https://github.com/proximax-storage)
+TypeScript & JS SDK | 0.8.0	| [Repository](https://github.com/proximax-storage/tsjs-xpx-chain-sdk) |	[Documentation](https://github.com/proximax-storage/tsjs-xpx-chain-sdk/wiki) |	[@proximax-storage](https://github.com/proximax-storage)
+Python SDK   | 0.6.5        | [Repository](https://github.com/proximax-storage/python-xpx-chain-sdk) | [Documentation](https://github.com/proximax-storage/python-xpx-chain-sdk/wiki) | [@proximax-storage](https://github.com/proximax-storage)
+Java SDK     | 0.6.2        | [Repository](https://github.com/proximax-storage/java-xpx-chain-sdk) |	[Documentation](https://github.com/proximax-storage/java-xpx-chain-sdk/wiki) |	[@proximax-storage](https://github.com/proximax-storage)
+C# SDK 	     | 0.6.2        | [Repository](https://github.com/proximax-storage/csharp-xpx-chain-sdk/ ) 	| [Documentation](https://github.com/proximax-storage/csharp-xpx-chain-sdk/wiki) | 	[@proximax-storage](https://github.com/proximax-storage)
+Dart SDK     | 0.0.5+4      | [Repository](https://github.com/proximax-storage/dart-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/dart-xpx-chain-sdk/wiki) | [@proximax-storage](https://github.com/proximax-storage)
+Rust SDK     | 0.4.16	    | [Repository](https://github.com/proximax-storage/rust-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/rust-xpx-chain-sdk/wiki) | [@proximax-storage](https://github.com/proximax-storage)
+PHP SDK      | 0.1.0	    | [Repository](https://github.com/proximax-storage/php-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/php-xpx-chain-sdk/wiki)  | [@proximax-storage](https://github.com/proximax-storage)
+
 
 ## Ongoing work
 
@@ -22,6 +24,5 @@ The following repositories have not been tested by the community, they are under
 
 **Language** |	**Repository** |	**Reference** |	**Active Developers**
 -------------|-----------------|------------------|-----------------------------
-C++ 	  | [Repository](https://github.com/proximax-storage/cpp-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/cpp-xpx-chain-sdk/wiki)  | [@proximax-storage](https://github.com/proximax-storage) 
-Swift SDK |	[Repository](https://github.com/proximax-storage/swift-xpx-chain-sdk/) 	| [Documentation](https://github.com/proximax-storage/swift-xpx-chain-sdk/wiki) | 	[@proximax-storage](https://github.com/proximax-storage) 
-Rust SDK 	| [Repository](https://github.com/proximax-storage/rust-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/rust-xpx-chain-sdk/wiki) | Open for contribution, please click [here](mailto:info@proximax.io) to email us
+C++ 	  | [Repository](https://github.com/proximax-storage/cpp-xpx-chain-sdk/) | [Documentation](https://github.com/proximax-storage/cpp-xpx-chain-sdk/wiki)  | [@proximax-storage](https://github.com/proximax-storage)
+Swift SDK |	[Repository](https://github.com/proximax-storage/swift-xpx-chain-sdk/) 	| [Documentation](https://github.com/proximax-storage/swift-xpx-chain-sdk/wiki) | Open for contribution, please click [here](mailto:info@proximax.io) to email us

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -30,7 +30,7 @@ class HomeSplash extends React.Component {
             Proximax Sirius extends traditional blockchain protocols by integrating off-chain,
             peer-to-peer storage, streaming, and database service layers.
             </h6>
-          <p>Sirius Chain Version <span>0.4.2</span></p>
+          <p>Sirius Chain Version <span>0.6.5</span></p>
         </div>
       </div>
     );


### PR DESCRIPTION
- Update all the chain SDKs to latest version
- Update chain version 0.4.2 to 0.6.5