### PR TITLE
Updating routes in swagger file by referring xpx chain rest

### DIFF
--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -468,7 +468,222 @@ paths:
           description: resource not found
         "409":
           description: invalid argument
-          
+  "/account/{accountId}/operations":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/operation/{hash256}":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/drive/{accountId}":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/drives":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/account/{accountId}/drive${state.routePostfix}":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/drive/{accountId}/downloads":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/account/{accountId}/downloads":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/downloads/{operationToken}":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
   "/blocks/{height}/limit/{limit}":
     get:
       tags:

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -366,7 +366,6 @@ paths:
           description: invalid content
         "409":
           description: invalid argument      
-   
    "/account/{accountId}/metadata":
       get:
        tags:

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -210,6 +210,265 @@ paths:
           description: resource not found
         "409":
           description: invalid argument
+  "/account/{accountId}/harvesting":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  /harvesters:
+    post:
+      tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      requestBody:
+        $ref: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "400":
+          description: invalid content
+        "409":
+          description: invalid argument
+  "/account/{accountId}/contracts":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/contract/{contractId}":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  /account/contracts:
+    post:
+      tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      requestBody:
+        $ref: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "400":
+          description: invalid content
+        "409":
+          description: invalid argument       
+   /contract:
+    post:
+      tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      requestBody:
+        $ref: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "400":
+          description: invalid content
+        "409":
+          description: invalid argument      
+  "/account/{accountId}/exchange":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/account/{accountId}/lock/hash":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/account/{accountId}/lock/secret":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+  "/account/{accountId}/metadata":
+      get:
+       tags:
+      - Account routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: The public key or address of the account.
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+          
   "/blocks/{height}/limit/{limit}":
     get:
       tags:

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -360,87 +360,8 @@ paths:
           description: invalid content
         "409":
           description: invalid argument      
-  "/account/{accountId}/exchange":
-      get:
-       tags:
-      - Account routes
-      summary: // To Be Updated
-      description: // To Be Updated
-      operationId: // To Be Updated
-      parameters:
-      - name: accountId
-        in: path
-        description: The public key or address of the account.
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          description: success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: //To Be Updated
-        "404":
-          description: resource not found
-        "409":
-          description: invalid argument
-   "/account/{accountId}/lock/hash":
-      get:
-       tags:
-      - Account routes
-      summary: // To Be Updated
-      description: // To Be Updated
-      operationId: // To Be Updated
-      parameters:
-      - name: accountId
-        in: path
-        description: The public key or address of the account.
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          description: success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: //To Be Updated
-        "404":
-          description: resource not found
-        "409":
-          description: invalid argument
-  "/account/{accountId}/lock/secret":
-      get:
-       tags:
-      - Account routes
-      summary: // To Be Updated
-      description: // To Be Updated
-      operationId: // To Be Updated
-      parameters:
-      - name: accountId
-        in: path
-        description: The public key or address of the account.
-        required: true
-        schema:
-          type: string
-      responses:
-        "200":
-          description: success
-          content:
-            application/json:
-              schema:
-                type: array
-                items:
-                  $ref: //To Be Updated
-        "404":
-          description: resource not found
-        "409":
-          description: invalid argument
+   
+  
   "/account/{accountId}/metadata":
       get:
        tags:
@@ -684,6 +605,8 @@ paths:
           description: resource not found
         "409":
           description: invalid argument
+          
+  
   "/blocks/{height}/limit/{limit}":
     get:
       tags:
@@ -855,6 +778,7 @@ paths:
           description: resource not found
         "409":
           description: invalid argument
+  
   /chain/height:
     get:
       tags:

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -50,6 +50,12 @@ tags:
 - name: Exchange routes
   description: |
     Exchange related endpoints.
+- name: Liquidity provider routes
+  description: |
+    Liquidity provider related endpoints.
+- name: Supercontract routes
+  description: |
+    Supercontract related endpoints.
     
 paths:
   "/account/{accountId}":
@@ -1809,6 +1815,154 @@ paths:
           description: resource not found
         "409":
           description: invalid argument
+          
+   "/liquidity_providers":
+      get:
+       tags:
+      - Liquidity providers routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: // To Be Updated
+        in: path
+        description: // To Be Updated
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: //To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/liquidity_providers/{providerKey}":
+    get:
+      tags:
+      - Liquidity providers routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: providerKey
+        in: path
+        description: // To Be Updated
+        required: true
+        schema:
+          type: string
+          enum: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+    
+   "/drive/{publicKey}/supercontracts":
+    get:
+      tags:
+      - Supercontract routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: publicKey
+        in: path
+        description: // To Be Updated
+        required: true
+        schema:
+          type: string
+          enum: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+    
+   "/supercontract/{accountId}":
+    get:
+      tags:
+      - Supercontract routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: accountId
+        in: path
+        description: // To Be Updated
+        required: true
+        schema:
+          type: string
+          enum: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+   "/account/{publicKey}/supercontracts":
+    get:
+      tags:
+      - Supercontract routes
+      summary: // To Be Updated
+      description: // To Be Updated
+      operationId: // To Be Updated
+      parameters:
+      - name: publicKey
+        in: path
+        description: // To Be Updated
+        required: true
+        schema:
+          type: string
+          enum: // To Be Updated
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: // To Be Updated
+                description: // To Be Updated
+                items:
+                  $ref: // To Be Updated
+        "404":
+          description: resource not found
+        "409":
+          description: invalid argument
+
+
   
 externalDocs:
   description: ProximaX Developer Center

--- a/website/static/downloads/swagger.yaml
+++ b/website/static/downloads/swagger.yaml
@@ -367,8 +367,7 @@ paths:
         "409":
           description: invalid argument      
    
-  
-  "/account/{accountId}/metadata":
+   "/account/{accountId}/metadata":
       get:
        tags:
       - Account routes


### PR DESCRIPTION
I have made the updates to the routes in the swagger.yaml from xpx-chain-devportal-docs/ website/ static/ downloads/swagger.yaml.  by referencing js-xpx-chain-rest/rest/src/plugins/routes.  (except for storage routes).